### PR TITLE
chore: update CI for self-maintenance

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,11 +23,11 @@ jobs:
         # get current commit hash
         CURRENT_HASH=$(git rev-parse HEAD)
         # get last commit hash of last build dist
-        LAST_BUILD_HASH=$(git log --author=google-github-actions-bot -1 --pretty=format:"%H")
+        LAST_BUILD_HASH=$(git log --author=stainless-bot -1 --pretty=format:"%H")
         DIFF=""
         # build and commit dist if diff
-        git config --global user.name "actions-bot"
-        git config user.email 'github-actions-bot@google.com'
+        git config --global user.name "stainless-bot"
+        git config user.email 'dev@stainless.com'
         git add dist/
         git diff-index --quiet HEAD || git commit -m "chore: build dist ${ACTION_NAME}"
         # if last commit hash of last build dist was found, get logs of commits in btw for PR body
@@ -49,7 +49,7 @@ jobs:
       with:
         token: ${{ secrets.ACTIONS_BOT_TOKEN }}
         commit-message: Build dist
-        author: "actions-bot <github-actions-bot@google.com>"
+        author: "actions-bot <dev@stainlessapi.com>"
         title: "chore: build dist"
         body: |
           Build dist PR
@@ -57,12 +57,11 @@ jobs:
         labels: automated pr
         branch: create-pull-request/build-dist
         delete-branch: true
-        push-to-fork: google-github-actions-bot/${{env.ACTION_NAME}}
   release-please-release:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@main
+      - uses: stainless-api/release-please-action@main
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,7 +73,7 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN}}@github.com/google-github-actions/release-please-action.git"
+          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN}}@github.com/stainless-api/release-please-action.git"
           git tag -d v${{ steps.release.outputs.major }} || true
           git tag -d v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
           git push origin :v${{ steps.release.outputs.major }} || true
@@ -91,7 +90,7 @@ jobs:
       - release-please-release
     steps:
       - id: release-pr
-        uses: GoogleCloudPlatform/release-please-action@main
+        uses: stainless-api/release-please-action@main
         with:
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           release-type: node


### PR DESCRIPTION
This PR is a start at a setup for ensuring we can easily use a custom version of this action so that any modifications we need to make to `release-please` can be used straight away without potentially having to wait for a PR to be accepted.